### PR TITLE
_retina-sprites.scss  performance improvement

### DIFF
--- a/src/_retina-sprites.scss
+++ b/src/_retina-sprites.scss
@@ -12,24 +12,23 @@
  */
 
 //first we'll define the folders where the sprites are and their layouts
-$icons: sprite-map("icons/*.png", $layout: smart);
-$icons-2x: sprite-map("icons-2x/*.png", $layout: smart);
+@import "icons/*.png";
+@import "icons-2x/*.png";
 
 //Sprite mixin, works perfectly with standard defines
 @mixin use-sprite($sprite) {
-    background-image: sprite-url($icons);
-    background-position: sprite-position($icons, $sprite);
+    @include icons-sprite($sprite); 
     background-repeat: no-repeat;
     overflow: hidden;
-    display: block;
-    height: image-height(sprite-file($icons, $sprite));
-    width: image-width(sprite-file($icons, $sprite));
+    display: inline-block;
+    height: icons-sprite-height($sprite);
+    width: icons-sprite-width($sprite);
 
     @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
-        background-image: sprite-url($icons-2x);
-        background-size: (image-width(sprite-path($icons-2x)) / 2) (image-height(sprite-path($icons-2x)) / 2);
-        background-position: round(nth(sprite-position($icons-2x, $sprite), 1) / 2) round(nth(sprite-position($icons-2x, $sprite), 2) / 2);
-        height: image-height(sprite-file($icons-2x, $sprite)) / 2;
-        width: image-width(sprite-file($icons-2x, $sprite)) / 2;
+        background-repeat: no-repeat;
+        overflow: hidden;
+        display: inline-block;
+        height: icons-2x-sprite-height($sprite);
+        width: icons-2x-sprite-width($sprite);
     }
 }


### PR DESCRIPTION
the sprite image are remove - rebuild many times also,

it waste a huge performance and sometimes cause sass building css failed.
I use @import to switch the sprite-map() function, now it's good to work:)

it only check sprite image one time after I saved file :)
